### PR TITLE
Refactors in CPP05

### DIFF
--- a/cpp05/ex00/include/Bureaucrat.hpp
+++ b/cpp05/ex00/include/Bureaucrat.hpp
@@ -7,8 +7,8 @@
 class Bureaucrat
 {
 private:
-    const std::string _name;
-    int _grade;
+    const std::string name_;
+    int grade_;
 
     static void validateGrade(int grade);
 

--- a/cpp05/ex00/src/Bureaucrat.cpp
+++ b/cpp05/ex00/src/Bureaucrat.cpp
@@ -7,8 +7,8 @@ Bureaucrat::Bureaucrat() {
 Bureaucrat::~Bureaucrat()
 {
     std::cout << "Bureaucrat destructor called";
-    if (!_name.empty())
-        std::cout << " for " << _name << " with grade " << _grade;
+    if (!name_.empty())
+        std::cout << " for " << name_ << " with grade " << grade_;
     std::cout << std::endl;
 }
 
@@ -19,21 +19,21 @@ void Bureaucrat::validateGrade(int grade) {
         throw(GradeTooLowException());
 }
 
-Bureaucrat::Bureaucrat(std::string name, int grade) : _name(name), _grade(grade)
+Bureaucrat::Bureaucrat(std::string name, int grade) : name_(name), grade_(grade)
 {
     validateGrade(grade);
     std::cout << "Bureaucrat " << name << " constructed with grade " << grade << std::endl;
 }
 
-Bureaucrat::Bureaucrat(const Bureaucrat &obj) {
-    _grade = obj._grade;
-    std::cout << "New Bureaucrat created from copy of Bureaucrat " << _name << std::endl;
+Bureaucrat::Bureaucrat(const Bureaucrat &obj) : name_(obj.name_), grade_(obj.grade_)
+{
+    std::cout << "New Bureaucrat created from copy of Bureaucrat " << obj.name_ << std::endl;
 }
 
 Bureaucrat &Bureaucrat::operator=(const Bureaucrat &obj)
 {
     if (this != &obj) {
-        this->_grade = obj._grade;
+        this->grade_ = obj.grade_;
     }
     std::cout << "Default Bureaucrat copy assignment called!" << std::endl;
     return (*this);
@@ -46,11 +46,11 @@ std::ostream &operator<<(std::ostream &out, const Bureaucrat &obj)
 }
 
 const std::string &Bureaucrat::getName() const {
-    return (_name);
+    return (name_);
 }
 
 int Bureaucrat::getGrade() const {
-    return (_grade);
+    return (grade_);
 }
 
 void Bureaucrat::incrementGrade() {

--- a/cpp05/ex00/src/Bureaucrat.cpp
+++ b/cpp05/ex00/src/Bureaucrat.cpp
@@ -54,15 +54,15 @@ int Bureaucrat::getGrade() const {
 }
 
 void Bureaucrat::incrementGrade() {
-    validateGrade(_grade + 1);
-    _grade += 1;
-    std::cout << _name << "'s grade incremented, now: " << _grade << std::endl;
+    validateGrade(grade_ - 1);
+    grade_ -= 1;
+    std::cout << name_ << "'s grade incremented, now: " << grade_ << std::endl;
 }
 
 void Bureaucrat::decrementGrade() {
-    validateGrade(_grade - 1);
-    _grade -= 1;
-    std::cout << _name << "'s grade decremented, now: " << _grade << std::endl;
+    validateGrade(grade_ + 1);
+    grade_ += 1;
+    std::cout << name_ << "'s grade decremented, now: " << grade_ << std::endl;
 }
 
 const char *Bureaucrat::GradeTooHighException::what() const throw()

--- a/cpp05/ex00/test/BureaucratTest.cpp
+++ b/cpp05/ex00/test/BureaucratTest.cpp
@@ -48,7 +48,7 @@ int main()
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 6: FUNCIONALITY: INCREMENT AND DECREMENT GRADE =====" << RESET << std::endl;
     {
         std::cout << CYAN;
-        Bureaucrat a6("A6", 100);
+        Bureaucrat a6("A6", 3);
         std::cout << BOLDGREEN;
         a6.incrementGrade();
         std::cout << BOLDYELLOW;
@@ -60,9 +60,7 @@ int main()
     {
         try
         {
-            std::cout << BRIGHT_CYAN;
             Bureaucrat a7("A7", 0);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -70,28 +68,26 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: DECREMENTING HIGHEST GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: INCREMENTING HIGHEST GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a8("A8", 1);
         try
         {
-            std::cout << BRIGHT_BLUE;
-            Bureaucrat a8("A8", 1);
-            a8.decrementGrade();
-            std::cout << DIM << GRAY;
+            a8.incrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 9: LOW EXCEPTION: INITIALIZING WITH BELOW MINUMUM GRADE (151) =====" << RESET << std::endl;
     {
         try
         {
-            std::cout << BRIGHT_MAGENTA;
             Bureaucrat a9("A9", 151);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -99,19 +95,19 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: INCREMENTING MINIMUM GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: DECREMENTING MINIMUM GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a10("A10", 150);
         try
         {
-            std::cout << BRIGHT_GREEN;
-            Bureaucrat a10("A10", 150);
-            a10.incrementGrade();
-            std::cout << DIM << GRAY;
+            a10.decrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << std::endl;

--- a/cpp05/ex01/include/Bureaucrat.hpp
+++ b/cpp05/ex01/include/Bureaucrat.hpp
@@ -10,8 +10,8 @@ class Form;
 class Bureaucrat
 {
 private:
-    const std::string _name;
-    int _grade;
+    const std::string name_;
+    int grade_;
 
     static void validateGrade(int grade);
 

--- a/cpp05/ex01/include/Form.hpp
+++ b/cpp05/ex01/include/Form.hpp
@@ -10,10 +10,10 @@ class Bureaucrat;
 class Form
 {
 private:
-    const std::string _name;
-    bool _isSigned;
-    const int _MinSignGrade;
-    const int _MinExecGrade;
+    const std::string name_;
+    bool isSigned_;
+    const int MinSignGrade_;
+    const int MinExecGrade_;
 
     static void validateGrade(int grade);
 
@@ -24,10 +24,10 @@ public:
     Form(const Form &obj);
     Form &operator=(const Form &obj);
 
-    const std::string &getName() const;
-    const bool &getIsSigned() const;
-    const int &getMinSignGrade() const;
-    const int &getMinExecGrade() const;
+    const std::string &getName() const { return (name_); }
+    const bool &getIsSigned() const { return (isSigned_); }
+    const int &getMinSignGrade() const { return (MinSignGrade_); }
+    const int &getMinExecGrade() const { return (MinExecGrade_); }
 
     bool beSigned(const Bureaucrat &b);
 

--- a/cpp05/ex01/src/Bureaucrat.cpp
+++ b/cpp05/ex01/src/Bureaucrat.cpp
@@ -8,8 +8,8 @@ Bureaucrat::Bureaucrat()
 Bureaucrat::~Bureaucrat()
 {
     std::cout << "Bureaucrat destructor called";
-    if (!_name.empty())
-        std::cout << " for " << _name << " with grade " << _grade;
+    if (!name_.empty())
+        std::cout << " for " << name_ << " with grade " << grade_;
     std::cout << std::endl;
 }
 
@@ -21,7 +21,7 @@ void Bureaucrat::validateGrade(int grade)
         throw(GradeTooLowException());
 }
 
-Bureaucrat::Bureaucrat(std::string name, int grade) : _name(name), _grade(grade)
+Bureaucrat::Bureaucrat(std::string name, int grade) : name_(name), grade_(grade)
 {
     validateGrade(grade);
     std::cout << "Bureaucrat " << name << " constructed with grade " << grade << std::endl;
@@ -29,15 +29,15 @@ Bureaucrat::Bureaucrat(std::string name, int grade) : _name(name), _grade(grade)
 
 Bureaucrat::Bureaucrat(const Bureaucrat &obj)
 {
-    _grade = obj._grade;
-    std::cout << "New Bureaucrat created from copy of Bureaucrat " << _name << std::endl;
+    grade_ = obj.grade_;
+    std::cout << "New Bureaucrat created from copy of Bureaucrat " << name_ << std::endl;
 }
 
 Bureaucrat &Bureaucrat::operator=(const Bureaucrat &obj)
 {
     if (this != &obj)
     {
-        this->_grade = obj._grade;
+        this->grade_ = obj.grade_;
     }
     std::cout << "Default Bureaucrat copy assignment called!" << std::endl;
     return (*this);
@@ -51,12 +51,12 @@ std::ostream &operator<<(std::ostream &out, const Bureaucrat &obj)
 
 const std::string &Bureaucrat::getName() const
 {
-    return (_name);
+    return (name_);
 }
 
 int Bureaucrat::getGrade() const
 {
-    return (_grade);
+    return (grade_);
 }
 
 void Bureaucrat::incrementGrade()
@@ -76,10 +76,10 @@ void Bureaucrat::signForm(Form &obj) {
 
     try {
         obj.beSigned(*this);
-        std::cout << _name << " signed " << obj.getName() << std::endl;
+        std::cout << name_ << " signed " << obj.getName() << std::endl;
     }
     catch (std::exception &e) {
-        std::cout << _name << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
+        std::cout << name_ << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
     }
 }
 

--- a/cpp05/ex01/src/Bureaucrat.cpp
+++ b/cpp05/ex01/src/Bureaucrat.cpp
@@ -61,15 +61,16 @@ int Bureaucrat::getGrade() const
 
 void Bureaucrat::incrementGrade()
 {
-    validateGrade(_grade + 1);
-    _grade += 1;
-    std::cout << _name << "'s grade incremented, now: " << _grade << std::endl;
+    validateGrade(grade_ - 1);
+    grade_ -= 1;
+    std::cout << name_ << "'s grade incremented, now: " << grade_ << std::endl;
 }
 
-void Bureaucrat::decrementGrade() {
-    validateGrade(_grade - 1);
-    _grade -= 1;
-    std::cout << _name << "'s grade decremented, now: " << _grade << std::endl;
+void Bureaucrat::decrementGrade()
+{
+    validateGrade(grade_ + 1);
+    grade_ += 1;
+    std::cout << name_ << "'s grade decremented, now: " << grade_ << std::endl;
 }
 
 void Bureaucrat::signForm(Form &obj) {

--- a/cpp05/ex01/src/Form.cpp
+++ b/cpp05/ex01/src/Form.cpp
@@ -26,8 +26,11 @@ Form &Form::operator=(const Form &obj) {
 }
 
 bool Form::beSigned(const Bureaucrat &obj) {
-    if (obj.getGrade() <= _MinSignGrade) {
-        _isSigned = true;
+    if (obj.getGrade() <= MinSignGrade_) {
+        if (isSigned_)
+            std::cout << obj.getName() << " couln't sign " << name_ << " because it's already signed.";
+        else
+        isSigned_ = true;
     }
     else
         throw GradeTooLowException();

--- a/cpp05/ex01/src/Form.cpp
+++ b/cpp05/ex01/src/Form.cpp
@@ -1,7 +1,8 @@
 #include "../include/Form.hpp"
 #include "../include/Bureaucrat.hpp"
 
-Form::Form(const std::string &name, int MinSignGrade, int MinExecGrade) : _name(name), _MinSignGrade(MinSignGrade), _MinExecGrade(MinExecGrade) {
+Form::Form(const std::string &name, int MinSignGrade, int MinExecGrade)
+    : name_(name), isSigned_(false), MinSignGrade_(MinSignGrade), MinExecGrade_(MinExecGrade) {
     validateGrade(MinSignGrade);
     validateGrade(MinExecGrade);
     _isSigned = false;
@@ -13,22 +14,17 @@ Form::~Form()
     std::cout << DIM << GRAY << "Form destructed. " << RESET << *this;
 }
 
-Form::Form(const Form &obj) : _name(obj._name), _isSigned(obj._isSigned), _MinSignGrade(obj._MinSignGrade), _MinExecGrade(obj._MinExecGrade) {
+Form::Form(const Form &obj) : name_(obj.name_), isSigned_(obj.isSigned_), MinSignGrade_(obj.MinSignGrade_), MinExecGrade_(obj.MinExecGrade_) {
     std::cout << CYAN << "Copy!" << RESET << " New form created. Form is a copy of: " << obj << std::endl;
 }
 
 Form &Form::operator=(const Form &obj) {
     if (this != &obj) {
-        _isSigned = obj._isSigned;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Now \"" << _name << "\" copied \"" << obj._name << "\"'s isSigned bool!" << std::endl;
+        isSigned_ = obj.isSigned_;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " \"" << name_ << "\" copied \"" << obj.name_ << "\"." << std::endl;
     }
     return *this;
 }
-
-const std::string &Form::getName() const     { return (_name); }
-const bool &Form::getIsSigned() const        { return (_isSigned); }
-const int &Form::getMinSignGrade() const     { return (_MinSignGrade); }
-const int &Form::getMinExecGrade() const     { return (_MinExecGrade); }
 
 bool Form::beSigned(const Bureaucrat &obj) {
     if (obj.getGrade() <= _MinSignGrade) {
@@ -36,7 +32,7 @@ bool Form::beSigned(const Bureaucrat &obj) {
     }
     else
         throw GradeTooLowException();
-    return (_isSigned);
+    return (isSigned_);
 }
 
 std::ostream &operator<<(std::ostream &out, const Form &obj){

--- a/cpp05/ex01/src/Form.cpp
+++ b/cpp05/ex01/src/Form.cpp
@@ -5,7 +5,6 @@ Form::Form(const std::string &name, int MinSignGrade, int MinExecGrade)
     : name_(name), isSigned_(false), MinSignGrade_(MinSignGrade), MinExecGrade_(MinExecGrade) {
     validateGrade(MinSignGrade);
     validateGrade(MinExecGrade);
-    _isSigned = false;
     std::cout << BOLDGREEN << "Form constructed! " << RESET << *this;
 }
 

--- a/cpp05/ex01/test/BureaucratTest.cpp
+++ b/cpp05/ex01/test/BureaucratTest.cpp
@@ -48,7 +48,7 @@ int main()
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 6: FUNCIONALITY: INCREMENT AND DECREMENT GRADE =====" << RESET << std::endl;
     {
         std::cout << CYAN;
-        Bureaucrat a6("A6", 100);
+        Bureaucrat a6("A6", 3);
         std::cout << BOLDGREEN;
         a6.incrementGrade();
         std::cout << BOLDYELLOW;
@@ -60,9 +60,7 @@ int main()
     {
         try
         {
-            std::cout << BRIGHT_CYAN;
             Bureaucrat a7("A7", 0);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -70,28 +68,26 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: DECREMENTING HIGHEST GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: INCREMENTING HIGHEST GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a8("A8", 1);
         try
         {
-            std::cout << BRIGHT_BLUE;
-            Bureaucrat a8("A8", 1);
-            a8.decrementGrade();
-            std::cout << DIM << GRAY;
+            a8.incrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 9: LOW EXCEPTION: INITIALIZING WITH BELOW MINUMUM GRADE (151) =====" << RESET << std::endl;
     {
         try
         {
-            std::cout << BRIGHT_MAGENTA;
             Bureaucrat a9("A9", 151);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -99,19 +95,19 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: INCREMENTING MINIMUM GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: DECREMENTING MINIMUM GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a10("A10", 150);
         try
         {
-            std::cout << BRIGHT_GREEN;
-            Bureaucrat a10("A10", 150);
-            a10.incrementGrade();
-            std::cout << DIM << GRAY;
+            a10.decrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << std::endl;

--- a/cpp05/ex01/test/FormTest.cpp
+++ b/cpp05/ex01/test/FormTest.cpp
@@ -2,23 +2,32 @@
 #include "../include/Colors.hpp"
 #include "../include/Form.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: FUNCTIONALITY: NAMED FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+    printTestLine("1", "FUNCTIONALITY –  NAMED FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         Form form1("Form 1", 20, 50);
     }
 
-    std::cout << std::endl << RESET << BOLDYELLOW << "\n===== TEST 2: FUNCTIONALITY: FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY – FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         Form form2("Form 2", 10, 2);
         Form form2copy(form2);
     }
 
-    std::cout << std::endl << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: OPERATOR << OVERLOAD =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY – OPERATOR << OVERLOAD");
     {
         std::cout << std::endl;
         Form form5("Form 5", 5, 5);
@@ -26,7 +35,7 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << std::endl << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY SIGN A FORM WITH EXACT GRADE =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY – SUCESSFULLY SIGN A FORM WITH EXACT GRADE");
     {
         std::cout << std::endl;
         Form form6("Form 6", 100, 100);
@@ -35,7 +44,7 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << std::endl << RESET << BOLDYELLOW << "\n===== TEST 5: FUNCTIONALITY: FORM COPY ASSIGNMENT WITH DIFFERENT BOOLS =====" << RESET << std::endl;
+    printTestLine("5", "FUNCTIONALITY – FORM COPY ASSIGNMENT WITH DIFFERENT BOOLS");
     {
         std::cout << std::endl;
         Form form7("Form 7", 100, 100);
@@ -45,7 +54,7 @@ int main()
         aux = form7;
     }
 
-    std::cout << std::endl << RESET << BOLDYELLOW << "\n===== TEST 6: ERROR: TRYING TO SIGN A FORM WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("6", "ERROR – TRYING TO SIGN A FORM WITH NOT ENOUGH GRADE");
     {
         try
         {
@@ -61,5 +70,36 @@ int main()
         }
     }
 
+    printTestLine("7", "ERROR – SIGNING AN ALREADY SIGNED FORM");
+    {
+        Form f("DoubleSign", 100, 100);
+        Bureaucrat b("Signer", 50);
+
+        b.signForm(f);
+        b.signForm(f);
+    }
+
+    printTestLine("8", "ERROR – FORM CREATION WITH INVALID GRADES");
+    {
+        try
+        {
+            Form f1("InvalidHigh", 0, 10);
+        }
+        catch (std::exception &e)
+        {
+            std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
+        }
+
+        try
+        {
+            Form f2("InvalidLow", 100, 151);
+        }
+        catch (std::exception &e)
+        {
+            std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
+        }
+    }
+
+    std::cout << RESET << std::endl;
     return 0;
 }

--- a/cpp05/ex02/include/AForm.hpp
+++ b/cpp05/ex02/include/AForm.hpp
@@ -10,10 +10,10 @@ class Bureaucrat;
 class AForm
 {
 private:
-    const std::string _name;
-    bool _isSigned;
-    const int _MinSignGrade;
-    const int _MinExecGrade;
+    const std::string name_;
+    bool isSigned_;
+    const int MinSignGrade_;
+    const int MinExecGrade_;
 
     static void validateGrade(int grade);
 

--- a/cpp05/ex02/include/Bureaucrat.hpp
+++ b/cpp05/ex02/include/Bureaucrat.hpp
@@ -11,8 +11,8 @@ class AForm;
 class Bureaucrat
 {
 private:
-    const std::string _name;
-    int _grade;
+    const std::string name_;
+    int grade_;
 
     static void validateGrade(int grade);
 

--- a/cpp05/ex02/include/PresidentialPardonForm.hpp
+++ b/cpp05/ex02/include/PresidentialPardonForm.hpp
@@ -18,4 +18,3 @@ public:
 
     PresidentialPardonForm &operator=(const PresidentialPardonForm &obj);
 };
-std::ostream &operator<<(std::ostream &out, const PresidentialPardonForm &obj);

--- a/cpp05/ex02/include/PresidentialPardonForm.hpp
+++ b/cpp05/ex02/include/PresidentialPardonForm.hpp
@@ -7,7 +7,7 @@
 class PresidentialPardonForm : public AForm
 {
 private:
-    std::string _target;
+    std::string target_;
     virtual void execute(Bureaucrat const &executor) const;
 
 public:

--- a/cpp05/ex02/include/RobotomyRequestForm.hpp
+++ b/cpp05/ex02/include/RobotomyRequestForm.hpp
@@ -9,7 +9,7 @@
 class RobotomyRequestForm : public AForm
 {
 private:
-    std::string _target;
+    std::string target_;
     virtual void execute(Bureaucrat const &executor) const;
 
 public:

--- a/cpp05/ex02/include/RobotomyRequestForm.hpp
+++ b/cpp05/ex02/include/RobotomyRequestForm.hpp
@@ -20,4 +20,3 @@ public:
 
     RobotomyRequestForm &operator=(const RobotomyRequestForm &obj);
 };
-std::ostream &operator<<(std::ostream &out, const RobotomyRequestForm &obj);

--- a/cpp05/ex02/include/ShrubberyCreationForm.hpp
+++ b/cpp05/ex02/include/ShrubberyCreationForm.hpp
@@ -7,7 +7,7 @@
 class ShrubberyCreationForm : public AForm
 {
 private:
-    std::string _target;
+    std::string target_;
     virtual void execute(Bureaucrat const &executor) const;
 
 public:

--- a/cpp05/ex02/include/ShrubberyCreationForm.hpp
+++ b/cpp05/ex02/include/ShrubberyCreationForm.hpp
@@ -18,4 +18,3 @@ public:
 
     ShrubberyCreationForm &operator=(const ShrubberyCreationForm &obj);
 };
-std::ostream &operator<<(std::ostream &out, const ShrubberyCreationForm &obj);

--- a/cpp05/ex02/src/AForm.cpp
+++ b/cpp05/ex02/src/AForm.cpp
@@ -1,10 +1,10 @@
 #include "../include/AForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-AForm::AForm(const std::string &name, int MinSignGrade, int MinExecGrade) : _name(name), _MinSignGrade(MinSignGrade), _MinExecGrade(MinExecGrade) {
+AForm::AForm(const std::string &name, int MinSignGrade, int MinExecGrade) : name_(name), MinSignGrade_(MinSignGrade), MinExecGrade_(MinExecGrade) {
     validateGrade(MinSignGrade);
     validateGrade(MinExecGrade);
-    _isSigned = false;
+    isSigned_ = false;
     std::cout << BOLDGREEN << "AForm constructed!" << RESET << std::endl;
 }
 
@@ -13,30 +13,30 @@ AForm::~AForm()
     std::cout << DIM << GRAY << "AForm destructed. " << RESET << std::endl;
 }
 
-AForm::AForm(const AForm &obj) : _name(obj._name), _isSigned(obj._isSigned), _MinSignGrade(obj._MinSignGrade), _MinExecGrade(obj._MinExecGrade) {
+AForm::AForm(const AForm &obj) : name_(obj.name_), isSigned_(obj.isSigned_), MinSignGrade_(obj.MinSignGrade_), MinExecGrade_(obj.MinExecGrade_) {
     std::cout << CYAN << "Copy!" << RESET << " New AForm created. " << std::endl;
 }
 
 AForm &AForm::operator=(const AForm &obj) {
     if (this != &obj) {
-        _isSigned = obj._isSigned;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Now \"" << _name << "\" copied \"" << obj._name << "\"'s isSigned bool!" << std::endl;
+        isSigned_ = obj.isSigned_;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Now \"" << name_ << "\" copied \"" << obj.name_ << "\"'s isSigned bool!" << std::endl;
     }
     return *this;
 }
 
-const std::string &AForm::getName() const     { return (_name); }
-const bool &AForm::getIsSigned() const        { return (_isSigned); }
-const int &AForm::getMinSignGrade() const     { return (_MinSignGrade); }
-const int &AForm::getMinExecGrade() const     { return (_MinExecGrade); }
+const std::string &AForm::getName() const     { return (name_); }
+const bool &AForm::getIsSigned() const        { return (isSigned_); }
+const int &AForm::getMinSignGrade() const     { return (MinSignGrade_); }
+const int &AForm::getMinExecGrade() const     { return (MinExecGrade_); }
 
 bool AForm::beSigned(const Bureaucrat &obj) {
-    if (obj.getGrade() <= _MinSignGrade) {
-        _isSigned = true;
+    if (obj.getGrade() <= MinSignGrade_) {
+        isSigned_ = true;
     }
     else
         throw GradeTooLowException();
-    return (_isSigned);
+    return (isSigned_);
 }
 
 std::ostream &operator<<(std::ostream &out, const AForm &obj){
@@ -71,8 +71,8 @@ const char *AForm::FormNotSignedException::what() const throw()
 }
 
 void AForm::validateExecutionRequirements(Bureaucrat const &executor) const {
-    if (!_isSigned)
+    if (!isSigned_)
         throw FormNotSignedException();
-    if (executor.getGrade() > _MinExecGrade)
+    if (executor.getGrade() > MinExecGrade_)
         throw GradeTooLowException();
 }

--- a/cpp05/ex02/src/AForm.cpp
+++ b/cpp05/ex02/src/AForm.cpp
@@ -40,7 +40,7 @@ bool AForm::beSigned(const Bureaucrat &obj) {
 }
 
 std::ostream &operator<<(std::ostream &out, const AForm &obj){
-    std::cout << "AForm " << BOLDWHITE << obj.getName() << RESET
+    std::cout << "AForm type " << BOLDWHITE << obj.getName() << RESET
               << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
               << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
               << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
@@ -67,7 +67,7 @@ const char *AForm::GradeTooLowException::what() const throw()
 
 const char *AForm::FormNotSignedException::what() const throw()
 {
-    return "Form not signed! Form must signed in order to execute.";
+    return "Form not signed! Form must be signed in order to execute.";
 }
 
 void AForm::validateExecutionRequirements(Bureaucrat const &executor) const {

--- a/cpp05/ex02/src/Bureaucrat.cpp
+++ b/cpp05/ex02/src/Bureaucrat.cpp
@@ -7,8 +7,8 @@ Bureaucrat::Bureaucrat() {
 Bureaucrat::~Bureaucrat()
 {
     std::cout << GRAY << "Bureaucrat destructor called";
-    if (!_name.empty())
-        std::cout << " for " << _name << " with grade " << _grade;
+    if (!name_.empty())
+        std::cout << " for " << name_ << " with grade " << grade_;
     std::cout << "." << RESET << std::endl;
 }
 
@@ -19,21 +19,21 @@ void Bureaucrat::validateGrade(int grade) {
         throw(GradeTooLowException());
 }
 
-Bureaucrat::Bureaucrat(std::string name, int grade) : _name(name), _grade(grade)
+Bureaucrat::Bureaucrat(std::string name, int grade) : name_(name), grade_(grade)
 {
     validateGrade(grade);
-    std::cout << BOLDGREEN << "Bureaucrat " << _name << " constructed! " << RESET << "Grade " << _grade << "."<< std::endl;
+    std::cout << BOLDGREEN << "Bureaucrat " << name_ << " constructed! " << RESET << "Grade " << grade_ << "."<< std::endl;
 }
 
 Bureaucrat::Bureaucrat(const Bureaucrat &obj) {
-    _grade = obj._grade;
-    std::cout << "New Bureaucrat created from copy of Bureaucrat " << _name << std::endl;
+    grade_ = obj.grade_;
+    std::cout << "New Bureaucrat created from copy of Bureaucrat " << name_ << std::endl;
 }
 
 Bureaucrat &Bureaucrat::operator=(const Bureaucrat &obj)
 {
     if (this != &obj) {
-        this->_grade = obj._grade;
+        this->grade_ = obj.grade_;
     }
     std::cout << "Default Bureaucrat copy assignment called!" << std::endl;
     return (*this);
@@ -46,11 +46,11 @@ std::ostream &operator<<(std::ostream &out, const Bureaucrat &obj)
 }
 
 const std::string &Bureaucrat::getName() const {
-    return (_name);
+    return (name_);
 }
 
 int Bureaucrat::getGrade() const {
-    return (_grade);
+    return (grade_);
 }
 
 void Bureaucrat::incrementGrade() {
@@ -69,21 +69,21 @@ void Bureaucrat::signForm(AForm &obj) {
 
     try {
         obj.beSigned(*this);
-        std::cout << _name << BOLDBLUE << " signed " << RESET << obj.getName() << std::endl;
+        std::cout << name_ << BOLDBLUE << " signed " << RESET << obj.getName() << std::endl;
     }
     catch (std::exception &e) {
-        std::cout << _name << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
+        std::cout << name_ << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
     }
 }
 
 void Bureaucrat::executeForm(AForm const &form) {
     try {
         form.execute(*this);
-        std::cout << _name << BOLDMAGENTA << " executed " << RESET << form.getName() << std::endl;
+        std::cout << name_ << BOLDMAGENTA << " executed " << RESET << form.getName() << std::endl;
     }
     catch (std::exception &e)
     {
-        std::cout << _name << BOLDRED << " couldn't execute " << RESET << form.getName() << " because " << e.what() << std::endl;
+        std::cout << name_ << BOLDRED << " couldn't execute " << RESET << form.getName() << " because " << e.what() << std::endl;
     }
 }
 

--- a/cpp05/ex02/src/Bureaucrat.cpp
+++ b/cpp05/ex02/src/Bureaucrat.cpp
@@ -53,25 +53,30 @@ int Bureaucrat::getGrade() const {
     return (grade_);
 }
 
-void Bureaucrat::incrementGrade() {
-    validateGrade(grade_ + 1);
-    grade_ += 1;
+void Bureaucrat::incrementGrade()
+{
+    validateGrade(grade_ - 1);
+    grade_ -= 1;
     std::cout << name_ << "'s grade incremented, now: " << grade_ << std::endl;
 }
 
-void Bureaucrat::decrementGrade() {
-    validateGrade(grade_ - 1);
-    grade_ -= 1;
+void Bureaucrat::decrementGrade()
+{
+    validateGrade(grade_ + 1);
+    grade_ += 1;
     std::cout << name_ << "'s grade decremented, now: " << grade_ << std::endl;
 }
 
-void Bureaucrat::signForm(AForm &obj) {
+void Bureaucrat::signForm(AForm &obj)
+{
 
-    try {
+    try
+    {
         obj.beSigned(*this);
-        std::cout << name_ << BOLDBLUE << " signed " << RESET << obj.getName() << std::endl;
+        std::cout << name_ << " signed " << obj.getName() << std::endl;
     }
-    catch (std::exception &e) {
+    catch (std::exception &e)
+    {
         std::cout << name_ << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
     }
 }

--- a/cpp05/ex02/src/Bureaucrat.cpp
+++ b/cpp05/ex02/src/Bureaucrat.cpp
@@ -54,15 +54,15 @@ int Bureaucrat::getGrade() const {
 }
 
 void Bureaucrat::incrementGrade() {
-    validateGrade(_grade + 1);
-    _grade += 1;
-    std::cout << _name << "'s grade incremented, now: " << _grade << std::endl;
+    validateGrade(grade_ + 1);
+    grade_ += 1;
+    std::cout << name_ << "'s grade incremented, now: " << grade_ << std::endl;
 }
 
 void Bureaucrat::decrementGrade() {
-    validateGrade(_grade - 1);
-    _grade -= 1;
-    std::cout << _name << "'s grade decremented, now: " << _grade << std::endl;
+    validateGrade(grade_ - 1);
+    grade_ -= 1;
+    std::cout << name_ << "'s grade decremented, now: " << grade_ << std::endl;
 }
 
 void Bureaucrat::signForm(AForm &obj) {

--- a/cpp05/ex02/src/PresidentialPardonForm.cpp
+++ b/cpp05/ex02/src/PresidentialPardonForm.cpp
@@ -1,7 +1,7 @@
 #include "../include/PresidentialPardonForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-PresidentialPardonForm::PresidentialPardonForm(const std::string &target) : AForm("PresidentialPardonForm", 25, 5), _target(target) {
+PresidentialPardonForm::PresidentialPardonForm(const std::string &target) : AForm("PresidentialPardonForm", 25, 5), target_(target) {
     std::cout << BOLDGREEN << "PresidentialPardonForm constructed! " << std::endl << RESET;
 }
 
@@ -10,15 +10,15 @@ PresidentialPardonForm::~PresidentialPardonForm()
     std::cout << DIM << GRAY << "PresidentialPardonForm destructed. " << std::endl << RESET;
 }
 
-PresidentialPardonForm::PresidentialPardonForm(const PresidentialPardonForm &obj) : AForm(obj), _target(obj._target) {
+PresidentialPardonForm::PresidentialPardonForm(const PresidentialPardonForm &obj) : AForm(obj), target_(obj.target_) {
     std::cout << CYAN << "Copy!" << RESET << " New " << obj.getName() << " created." << std::endl;
 }
 
 PresidentialPardonForm &PresidentialPardonForm::operator=(const PresidentialPardonForm &obj) {
     if (this != &obj) {
         AForm::operator=(obj);
-        _target = obj._target;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
+        target_ = obj.target_;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << std::endl;
     }
     return *this;
 }
@@ -33,6 +33,6 @@ std::ostream &operator<<(std::ostream &out, const PresidentialPardonForm &obj) {
 
 void PresidentialPardonForm::execute(Bureaucrat const &executor) const {
     validateExecutionRequirements(executor);
-    std::cout << _target << " has been pardoned by Zaphod Beeblebrox." << std::endl;
+    std::cout << target_ << " has been pardoned by Zaphod Beeblebrox." << std::endl;
 }
 

--- a/cpp05/ex02/src/PresidentialPardonForm.cpp
+++ b/cpp05/ex02/src/PresidentialPardonForm.cpp
@@ -23,14 +23,6 @@ PresidentialPardonForm &PresidentialPardonForm::operator=(const PresidentialPard
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &out, const PresidentialPardonForm &obj) {
-    std::cout << "Type: " << BOLDWHITE << obj.getName() << RESET
-              << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
-              << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
-              << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
-    return (out);
-}
-
 void PresidentialPardonForm::execute(Bureaucrat const &executor) const {
     validateExecutionRequirements(executor);
     std::cout << target_ << " has been pardoned by Zaphod Beeblebrox." << std::endl;

--- a/cpp05/ex02/src/RobotomyRequestForm.cpp
+++ b/cpp05/ex02/src/RobotomyRequestForm.cpp
@@ -1,7 +1,7 @@
 #include "../include/RobotomyRequestForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-RobotomyRequestForm::RobotomyRequestForm(const std::string &target) : AForm("RobotomyRequestForm", 72, 45), _target(target) {
+RobotomyRequestForm::RobotomyRequestForm(const std::string &target) : AForm("RobotomyRequestForm", 72, 45), target_(target) {
     std::cout << BOLDGREEN << "RobotomyRequestForm constructed! " << std::endl << RESET;
 }
 
@@ -10,15 +10,15 @@ RobotomyRequestForm::~RobotomyRequestForm()
     std::cout << DIM << GRAY << "RobotomyRequestForm destructed. " << std::endl << RESET;
 }
 
-RobotomyRequestForm::RobotomyRequestForm(const RobotomyRequestForm &obj) : AForm(obj), _target(obj._target) {
+RobotomyRequestForm::RobotomyRequestForm(const RobotomyRequestForm &obj) : AForm(obj), target_(obj.target_) {
     std::cout << CYAN << "Copy!" << RESET << " New " << obj.getName() << " created." << std::endl;
 }
 
 RobotomyRequestForm &RobotomyRequestForm::operator=(const RobotomyRequestForm &obj) {
     if (this != &obj) {
         AForm::operator=(obj);
-        _target = obj._target;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
+        target_ = obj.target_;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << std::endl;
     }
     return *this;
 }
@@ -37,11 +37,11 @@ void RobotomyRequestForm::execute(Bureaucrat const &executor) const {
     std::srand(std::time(NULL));
     if (std::rand() % 2)
     {
-        std::cout << _target << " has been robotomized successfully." << std::endl;
+        std::cout << target_ << " has been robotomized successfully." << std::endl;
     }
     else
     {
-        std::cout << "The robotomy failed on " << _target << "." << std::endl;
+        std::cout << "The robotomy failed on " << target_ << "." << std::endl;
     }
 }
 

--- a/cpp05/ex02/src/RobotomyRequestForm.cpp
+++ b/cpp05/ex02/src/RobotomyRequestForm.cpp
@@ -23,14 +23,6 @@ RobotomyRequestForm &RobotomyRequestForm::operator=(const RobotomyRequestForm &o
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &out, const RobotomyRequestForm &obj) {
-    std::cout << "Type: " << BOLDWHITE << obj.getName() << RESET
-              << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
-              << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
-              << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
-    return (out);
-}
-
 void RobotomyRequestForm::execute(Bureaucrat const &executor) const {
     validateExecutionRequirements(executor);
     std::cout << "* Drilling noises *" << std::endl;

--- a/cpp05/ex02/src/ShrubberyCreationForm.cpp
+++ b/cpp05/ex02/src/ShrubberyCreationForm.cpp
@@ -1,7 +1,7 @@
 #include "../include/ShrubberyCreationForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target) : AForm("ShrubberyCreationForm", 145, 137), _target(target) {
+ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target) : AForm("ShrubberyCreationForm", 145, 137), target_(target) {
     std::cout << BOLDGREEN << "ShrubberyCreationForm constructed! " << std::endl << RESET;
 }
 
@@ -23,17 +23,9 @@ ShrubberyCreationForm &ShrubberyCreationForm::operator=(const ShrubberyCreationF
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &out, const ShrubberyCreationForm &obj) {
-    std::cout << "Type: " << BOLDWHITE << obj.getName() << RESET
-              << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
-              << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
-              << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
-    return (out);
-}
-
 void ShrubberyCreationForm::execute(Bureaucrat const &executor) const {
     validateExecutionRequirements(executor);
-    std::ofstream myFile((_target + "_shrubbery").c_str());
+    std::ofstream myFile((target_ + "_shrubbery").c_str());
     if (myFile) {
         myFile << "        /\\ \n"
                   "       /**\\ \n"

--- a/cpp05/ex02/src/ShrubberyCreationForm.cpp
+++ b/cpp05/ex02/src/ShrubberyCreationForm.cpp
@@ -10,15 +10,15 @@ ShrubberyCreationForm::~ShrubberyCreationForm()
     std::cout << DIM << GRAY << "ShrubberyCreationForm destructed. " << std::endl << RESET;
 }
 
-ShrubberyCreationForm::ShrubberyCreationForm(const ShrubberyCreationForm &obj) : AForm(obj), _target(obj._target) {
+ShrubberyCreationForm::ShrubberyCreationForm(const ShrubberyCreationForm &obj) : AForm(obj), target_(obj.target_) {
     std::cout << CYAN << "Copy!" << RESET << " New " << obj.getName() << " created." << std::endl;
 }
 
 ShrubberyCreationForm &ShrubberyCreationForm::operator=(const ShrubberyCreationForm &obj) {
     if (this != &obj) {
         AForm::operator=(obj);
-        _target = obj._target;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
+        target_ = obj.target_;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << std::endl;
     }
     return *this;
 }

--- a/cpp05/ex02/test/BureaucratTest.cpp
+++ b/cpp05/ex02/test/BureaucratTest.cpp
@@ -48,7 +48,7 @@ int main()
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 6: FUNCIONALITY: INCREMENT AND DECREMENT GRADE =====" << RESET << std::endl;
     {
         std::cout << CYAN;
-        Bureaucrat a6("A6", 100);
+        Bureaucrat a6("A6", 3);
         std::cout << BOLDGREEN;
         a6.incrementGrade();
         std::cout << BOLDYELLOW;
@@ -60,9 +60,7 @@ int main()
     {
         try
         {
-            std::cout << BRIGHT_CYAN;
             Bureaucrat a7("A7", 0);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -70,28 +68,26 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: DECREMENTING HIGHEST GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: INCREMENTING HIGHEST GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a8("A8", 1);
         try
         {
-            std::cout << BRIGHT_BLUE;
-            Bureaucrat a8("A8", 1);
-            a8.decrementGrade();
-            std::cout << DIM << GRAY;
+            a8.incrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 9: LOW EXCEPTION: INITIALIZING WITH BELOW MINUMUM GRADE (151) =====" << RESET << std::endl;
     {
         try
         {
-            std::cout << BRIGHT_MAGENTA;
             Bureaucrat a9("A9", 151);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -99,19 +95,19 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: INCREMENTING MINIMUM GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: DECREMENTING MINIMUM GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a10("A10", 150);
         try
         {
-            std::cout << BRIGHT_GREEN;
-            Bureaucrat a10("A10", 150);
-            a10.incrementGrade();
-            std::cout << DIM << GRAY;
+            a10.decrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << std::endl;

--- a/cpp05/ex02/test/PresidentialTest.cpp
+++ b/cpp05/ex02/test/PresidentialTest.cpp
@@ -2,32 +2,42 @@
 #include "../include/Colors.hpp"
 #include "../include/PresidentialPardonForm.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: PRESIDENTIAL PARDON FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+    printTestLine("1", "FUNCTIONALITY –  PRESIDENTIAL PARDON CREATION FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         PresidentialPardonForm form1("oi");
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: PRESIDENTIAL PARDON FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  PRESIDENTIAL PARDON FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         PresidentialPardonForm form2("oi");
         PresidentialPardonForm form2copy(form2);
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: SUCESSFULLY SIGN A FORM =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY –  SUCESSFULLY SIGN A FORM");
     {
         std::cout << GRAY << "Quick info: In order to sign Presidential Form, a Bureaucrat needs grade 25." << RESET << std::endl;
         std::cout << std::endl;
         PresidentialPardonForm form6("oi");
-        Bureaucrat b1("Bureaucrat 1", 5);
+        Bureaucrat b1("Bureaucrat 1", 25);
         b1.signForm(form6);
+        // b1.executeForm(form6); //Bureaucrat won't be able to execute
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY EXECUTE PARDON =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY –  SUCESSFULLY EXECUTE FORM");
     {
         std::cout << GRAY << "Quick info: In order to execute Presidential Form, a Bureaucrat needs grade 5." << RESET << std::endl;
         PresidentialPardonForm form6("oi");
@@ -37,13 +47,23 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: ERROR: TRYING TO EXECUTE ROBOTOMY WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("5", "ERROR –  TRYING TO EXECUTE FORM WITH NOT ENOUGH GRADE");
     {
         std::cout << GRAY << "Quick info: In order to execute Presidential Form, a Bureaucrat needs grade 5." << RESET << std::endl;
         std::cout << std::endl;
         PresidentialPardonForm form6("oi");
         Bureaucrat b1("Bureaucrat 3", 6);
         b1.signForm(form6);
+        b1.executeForm(form6);
+        std::cout << std::endl;
+    }
+
+    printTestLine("6", "ERROR –  TRYING TO EXECUTE UNSIGNED FORM");
+    {
+        std::cout << std::endl;
+        PresidentialPardonForm form6("oi");
+        Bureaucrat b1("Bureaucrat 6", 3);
+        // b1.signForm(form6);
         b1.executeForm(form6);
         std::cout << std::endl;
     }

--- a/cpp05/ex02/test/RobotomyTest.cpp
+++ b/cpp05/ex02/test/RobotomyTest.cpp
@@ -2,15 +2,24 @@
 #include "../include/Colors.hpp"
 #include "../include/RobotomyRequestForm.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: ROBOTOMY REQUEST FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+        printTestLine("1", "FUNCTIONALITY –  ROBOTOMY REQUEST FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         RobotomyRequestForm form1("oi");
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: ROBOTOMY REQUEST FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  ROBOTOMY REQUEST FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         RobotomyRequestForm form2("oi");
@@ -18,17 +27,18 @@ int main()
     }
 
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: SUCESSFULLY SIGN A FORM =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY –  SUCESSFULLY SIGN A FORM");
     {
         std::cout << GRAY << "Quick info: In order to sign Robotomy Form, a Bureaucrat needs grade 72." << RESET << std::endl;
         std::cout << std::endl;
         RobotomyRequestForm form6("oi");
-        Bureaucrat b1("Bureaucrat 6", 145);
+        Bureaucrat b1("Bureaucrat 6", 72);
+        //b1.executeForm(form6); //Bureaucrat won't be able to execute
         b1.signForm(form6);
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY EXECUTE ROBOTOMY =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY –  SUCESSFULLY EXECUTE FORM");
     {
         std::cout << GRAY << "Quick info: In order to execute Robotomy Form, a Bureaucrat needs grade 45." << RESET << std::endl;
         RobotomyRequestForm form6("oi");
@@ -38,13 +48,23 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: ERROR: TRYING TO EXECUTE ROBOTOMY WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("5", "ERROR –  TRYING TO EXECUTE FORM WITH NOT ENOUGH GRADE");
     {
         std::cout << GRAY << "Quick info: In order to execute Robotomy Form, a Bureaucrat needs grade 45." << RESET << std::endl;
         std::cout << std::endl;
         RobotomyRequestForm form6("oi");
         Bureaucrat b1("Bureaucrat 6", 71);
         b1.signForm(form6);
+        b1.executeForm(form6);
+        std::cout << std::endl;
+    }
+
+    printTestLine("6", "ERROR –  TRYING TO EXECUTE UNSIGNED FORM");
+    {
+        std::cout << std::endl;
+        RobotomyRequestForm form6("oi");
+        Bureaucrat b1("Bureaucrat 6", 144);
+        //b1.signForm(form6);
         b1.executeForm(form6);
         std::cout << std::endl;
     }

--- a/cpp05/ex02/test/ShrubberyTest.cpp
+++ b/cpp05/ex02/test/ShrubberyTest.cpp
@@ -2,33 +2,43 @@
 #include "../include/Colors.hpp"
 #include "../include/ShrubberyCreationForm.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: SHRUBBERY CREATION FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+    printTestLine("1", "FUNCTIONALITY –  SHRUBBERY CREATION FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         ShrubberyCreationForm form1("oi");
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: SHRUBBERY CREATION FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  SHRUBBERY CREATION FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         ShrubberyCreationForm form2("oi");
         ShrubberyCreationForm form2copy(form2);
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: SUCESSFULLY SIGN A FORM =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY –  SUCESSFULLY SIGN A FORM");
     {
         std::cout << GRAY << "Quick info: In order to sign Shrubbery Form, a Bureaucrat needs grade 145." << RESET << std::endl;
         std::cout << std::endl;
         ShrubberyCreationForm form6("oi");
         Bureaucrat b1("Bureaucrat 6", 145);
         b1.signForm(form6);
+        //b1.executeForm(form6); //Bureaucrat won't be able to execute
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY EXECUTE SHRUBBERY =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY –  SUCESSFULLY EXECUTE FORM");
     {
         std::cout << GRAY << "Quick info: In order to execute Shrubbery Form, a Bureaucrat needs grade 137." << RESET << std::endl;
         ShrubberyCreationForm form6("oi");
@@ -38,13 +48,23 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: ERROR: TRYING TO EXECUTE SHRUBBERY WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("5", "ERROR –  TRYING TO EXECUTE FORM WITH NOT ENOUGH GRADE");
     {
         std::cout << GRAY << "Quick info: In order to execute Shrubbery Form, a Bureaucrat needs grade 137." << RESET << std::endl;
         std::cout << std::endl;
         ShrubberyCreationForm form6("oi");
         Bureaucrat b1("Bureaucrat 6", 144);
         b1.signForm(form6);
+        b1.executeForm(form6);
+        std::cout << std::endl;
+    }
+
+    printTestLine("6", "ERROR –  TRYING TO EXECUTE UNSIGNED FORM");
+    {
+        std::cout << std::endl;
+        ShrubberyCreationForm form6("oi");
+        Bureaucrat b1("Bureaucrat 6", 144);
+        //b1.signForm(form6);
         b1.executeForm(form6);
         std::cout << std::endl;
     }

--- a/cpp05/ex03/include/AForm.hpp
+++ b/cpp05/ex03/include/AForm.hpp
@@ -10,10 +10,10 @@ class Bureaucrat;
 class AForm
 {
 private:
-    const std::string _name;
-    bool _isSigned;
-    const int _MinSignGrade;
-    const int _MinExecGrade;
+    const std::string name_;
+    bool isSigned_;
+    const int MinSignGrade_;
+    const int MinExecGrade_;
 
     static void validateGrade(int grade);
 

--- a/cpp05/ex03/include/Bureaucrat.hpp
+++ b/cpp05/ex03/include/Bureaucrat.hpp
@@ -11,8 +11,8 @@ class AForm;
 class Bureaucrat
 {
 private:
-    const std::string _name;
-    int _grade;
+    const std::string name_;
+    int grade_;
 
     static void validateGrade(int grade);
 

--- a/cpp05/ex03/include/PresidentialPardonForm.hpp
+++ b/cpp05/ex03/include/PresidentialPardonForm.hpp
@@ -18,4 +18,3 @@ public:
 
     PresidentialPardonForm &operator=(const PresidentialPardonForm &obj);
 };
-std::ostream &operator<<(std::ostream &out, const PresidentialPardonForm &obj);

--- a/cpp05/ex03/include/PresidentialPardonForm.hpp
+++ b/cpp05/ex03/include/PresidentialPardonForm.hpp
@@ -7,7 +7,7 @@
 class PresidentialPardonForm : public AForm
 {
 private:
-    std::string _target;
+    std::string target_;
     virtual void execute(Bureaucrat const &executor) const;
 
 public:

--- a/cpp05/ex03/include/RobotomyRequestForm.hpp
+++ b/cpp05/ex03/include/RobotomyRequestForm.hpp
@@ -9,7 +9,7 @@
 class RobotomyRequestForm : public AForm
 {
 private:
-    std::string _target;
+    std::string target_;
     virtual void execute(Bureaucrat const &executor) const;
 
 public:

--- a/cpp05/ex03/include/RobotomyRequestForm.hpp
+++ b/cpp05/ex03/include/RobotomyRequestForm.hpp
@@ -20,4 +20,3 @@ public:
 
     RobotomyRequestForm &operator=(const RobotomyRequestForm &obj);
 };
-std::ostream &operator<<(std::ostream &out, const RobotomyRequestForm &obj);

--- a/cpp05/ex03/include/ShrubberyCreationForm.hpp
+++ b/cpp05/ex03/include/ShrubberyCreationForm.hpp
@@ -7,7 +7,7 @@
 class ShrubberyCreationForm : public AForm
 {
 private:
-    std::string _target;
+    std::string target_;
     virtual void execute(Bureaucrat const &executor) const;
 
 public:

--- a/cpp05/ex03/include/ShrubberyCreationForm.hpp
+++ b/cpp05/ex03/include/ShrubberyCreationForm.hpp
@@ -18,4 +18,3 @@ public:
 
     ShrubberyCreationForm &operator=(const ShrubberyCreationForm &obj);
 };
-std::ostream &operator<<(std::ostream &out, const ShrubberyCreationForm &obj);

--- a/cpp05/ex03/src/AForm.cpp
+++ b/cpp05/ex03/src/AForm.cpp
@@ -1,10 +1,10 @@
 #include "../include/AForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-AForm::AForm(const std::string &name, int MinSignGrade, int MinExecGrade) : _name(name), _MinSignGrade(MinSignGrade), _MinExecGrade(MinExecGrade) {
+AForm::AForm(const std::string &name, int MinSignGrade, int MinExecGrade) : name_(name), MinSignGrade_(MinSignGrade), MinExecGrade_(MinExecGrade) {
     validateGrade(MinSignGrade);
     validateGrade(MinExecGrade);
-    _isSigned = false;
+    isSigned_ = false;
     std::cout << BOLDGREEN << "AForm constructed!" << RESET << std::endl;
 }
 
@@ -13,30 +13,30 @@ AForm::~AForm()
     std::cout << DIM << GRAY << "AForm destructed. " << RESET << std::endl;
 }
 
-AForm::AForm(const AForm &obj) : _name(obj._name), _isSigned(obj._isSigned), _MinSignGrade(obj._MinSignGrade), _MinExecGrade(obj._MinExecGrade) {
+AForm::AForm(const AForm &obj) : name_(obj.name_), isSigned_(obj.isSigned_), MinSignGrade_(obj.MinSignGrade_), MinExecGrade_(obj.MinExecGrade_) {
     std::cout << CYAN << "Copy!" << RESET << " New AForm created. " << std::endl;
 }
 
 AForm &AForm::operator=(const AForm &obj) {
     if (this != &obj) {
-        _isSigned = obj._isSigned;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Now \"" << _name << "\" copied \"" << obj._name << "\"'s isSigned bool!" << std::endl;
+        isSigned_ = obj.isSigned_;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Now \"" << name_ << "\" copied \"" << obj.name_ << "\"'s isSigned bool!" << std::endl;
     }
     return *this;
 }
 
-const std::string &AForm::getName() const     { return (_name); }
-const bool &AForm::getIsSigned() const        { return (_isSigned); }
-const int &AForm::getMinSignGrade() const     { return (_MinSignGrade); }
-const int &AForm::getMinExecGrade() const     { return (_MinExecGrade); }
+const std::string &AForm::getName() const     { return (name_); }
+const bool &AForm::getIsSigned() const        { return (isSigned_); }
+const int &AForm::getMinSignGrade() const     { return (MinSignGrade_); }
+const int &AForm::getMinExecGrade() const     { return (MinExecGrade_); }
 
 bool AForm::beSigned(const Bureaucrat &obj) {
-    if (obj.getGrade() <= _MinSignGrade) {
-        _isSigned = true;
+    if (obj.getGrade() <= MinSignGrade_) {
+        isSigned_ = true;
     }
     else
         throw GradeTooLowException();
-    return (_isSigned);
+    return (isSigned_);
 }
 
 std::ostream &operator<<(std::ostream &out, const AForm &obj){
@@ -71,8 +71,8 @@ const char *AForm::FormNotSignedException::what() const throw()
 }
 
 void AForm::validateExecutionRequirements(Bureaucrat const &executor) const {
-    if (!_isSigned)
+    if (!isSigned_)
         throw FormNotSignedException();
-    if (executor.getGrade() > _MinExecGrade)
+    if (executor.getGrade() > MinExecGrade_)
         throw GradeTooLowException();
 }

--- a/cpp05/ex03/src/Bureaucrat.cpp
+++ b/cpp05/ex03/src/Bureaucrat.cpp
@@ -7,8 +7,8 @@ Bureaucrat::Bureaucrat() {
 Bureaucrat::~Bureaucrat()
 {
     std::cout << GRAY << "Bureaucrat destructor called";
-    if (!_name.empty())
-        std::cout << " for " << _name << " with grade " << _grade;
+    if (!name_.empty())
+        std::cout << " for " << name_ << " with grade " << grade_;
     std::cout << "." << RESET << std::endl;
 }
 
@@ -19,21 +19,21 @@ void Bureaucrat::validateGrade(int grade) {
         throw(GradeTooLowException());
 }
 
-Bureaucrat::Bureaucrat(std::string name, int grade) : _name(name), _grade(grade)
+Bureaucrat::Bureaucrat(std::string name, int grade) : name_(name), grade_(grade)
 {
     validateGrade(grade);
     std::cout << BOLDGREEN << "Bureaucrat " << name << " constructed! " << RESET << "Grade " << grade << "."<< std::endl;
 }
 
 Bureaucrat::Bureaucrat(const Bureaucrat &obj) {
-    _grade = obj._grade;
-    std::cout << "New Bureaucrat created from copy of Bureaucrat " << _name << std::endl;
+    grade_ = obj.grade_;
+    std::cout << "New Bureaucrat created from copy of Bureaucrat " << name_ << std::endl;
 }
 
 Bureaucrat &Bureaucrat::operator=(const Bureaucrat &obj)
 {
     if (this != &obj) {
-        this->_grade = obj._grade;
+        this->grade_ = obj.grade_;
     }
     std::cout << "Default Bureaucrat copy assignment called!" << std::endl;
     return (*this);
@@ -46,11 +46,11 @@ std::ostream &operator<<(std::ostream &out, const Bureaucrat &obj)
 }
 
 const std::string &Bureaucrat::getName() const {
-    return (_name);
+    return (name_);
 }
 
 int Bureaucrat::getGrade() const {
-    return (_grade);
+    return (grade_);
 }
 
 void Bureaucrat::incrementGrade() {
@@ -69,21 +69,21 @@ void Bureaucrat::signForm(AForm &obj) {
 
     try {
         obj.beSigned(*this);
-        std::cout << _name << BOLDBLUE << " signed " << RESET << obj.getName() << std::endl;
+        std::cout << name_ << BOLDBLUE << " signed " << RESET << obj.getName() << std::endl;
     }
     catch (std::exception &e) {
-        std::cout << _name << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
+        std::cout << name_ << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
     }
 }
 
 void Bureaucrat::executeForm(AForm const &form) {
     try {
         form.execute(*this);
-        std::cout << _name << BOLDMAGENTA << " executed " << RESET << form.getName() << std::endl;
+        std::cout << name_ << BOLDMAGENTA << " executed " << RESET << form.getName() << std::endl;
     }
     catch (std::exception &e)
     {
-        std::cout << _name << BOLDRED << " couldn't execute " << RESET << form.getName() << " because " << e.what() << std::endl;
+        std::cout << name_ << BOLDRED << " couldn't execute " << RESET << form.getName() << " because " << e.what() << std::endl;
     }
 }
 

--- a/cpp05/ex03/src/Bureaucrat.cpp
+++ b/cpp05/ex03/src/Bureaucrat.cpp
@@ -53,25 +53,30 @@ int Bureaucrat::getGrade() const {
     return (grade_);
 }
 
-void Bureaucrat::incrementGrade() {
-    validateGrade(grade_ + 1);
-    grade_ += 1;
+void Bureaucrat::incrementGrade()
+{
+    validateGrade(grade_ - 1);
+    grade_ -= 1;
     std::cout << name_ << "'s grade incremented, now: " << grade_ << std::endl;
 }
 
-void Bureaucrat::decrementGrade() {
-    validateGrade(grade_ - 1);
-    grade_ -= 1;
+void Bureaucrat::decrementGrade()
+{
+    validateGrade(grade_ + 1);
+    grade_ += 1;
     std::cout << name_ << "'s grade decremented, now: " << grade_ << std::endl;
 }
 
-void Bureaucrat::signForm(AForm &obj) {
+void Bureaucrat::signForm(AForm &obj)
+{
 
-    try {
+    try
+    {
         obj.beSigned(*this);
-        std::cout << name_ << BOLDBLUE << " signed " << RESET << obj.getName() << std::endl;
+        std::cout << name_ << " signed " << obj.getName() << std::endl;
     }
-    catch (std::exception &e) {
+    catch (std::exception &e)
+    {
         std::cout << name_ << BOLDRED << " couldn't sign " << RESET << obj.getName() << " because " << e.what() << std::endl;
     }
 }

--- a/cpp05/ex03/src/Bureaucrat.cpp
+++ b/cpp05/ex03/src/Bureaucrat.cpp
@@ -54,15 +54,15 @@ int Bureaucrat::getGrade() const {
 }
 
 void Bureaucrat::incrementGrade() {
-    validateGrade(_grade + 1);
-    _grade += 1;
-    std::cout << _name << "'s grade incremented, now: " << _grade << std::endl;
+    validateGrade(grade_ + 1);
+    grade_ += 1;
+    std::cout << name_ << "'s grade incremented, now: " << grade_ << std::endl;
 }
 
 void Bureaucrat::decrementGrade() {
-    validateGrade(_grade - 1);
-    _grade -= 1;
-    std::cout << _name << "'s grade decremented, now: " << _grade << std::endl;
+    validateGrade(grade_ - 1);
+    grade_ -= 1;
+    std::cout << name_ << "'s grade decremented, now: " << grade_ << std::endl;
 }
 
 void Bureaucrat::signForm(AForm &obj) {

--- a/cpp05/ex03/src/PresidentialPardonForm.cpp
+++ b/cpp05/ex03/src/PresidentialPardonForm.cpp
@@ -1,7 +1,7 @@
 #include "../include/PresidentialPardonForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-PresidentialPardonForm::PresidentialPardonForm(const std::string &target) : AForm("PresidentialPardonForm", 25, 5), _target(target) {
+PresidentialPardonForm::PresidentialPardonForm(const std::string &target) : AForm("PresidentialPardonForm", 25, 5), target_(target) {
     std::cout << BOLDGREEN << "PresidentialPardonForm constructed! " << std::endl << RESET;
 }
 
@@ -10,14 +10,14 @@ PresidentialPardonForm::~PresidentialPardonForm()
     std::cout << DIM << GRAY << "PresidentialPardonForm destructed. " << std::endl << RESET;
 }
 
-PresidentialPardonForm::PresidentialPardonForm(const PresidentialPardonForm &obj) : AForm(obj), _target(obj._target) {
+PresidentialPardonForm::PresidentialPardonForm(const PresidentialPardonForm &obj) : AForm(obj), target_(obj.target_) {
     std::cout << CYAN << "Copy!" << RESET << " New " << obj.getName() << " created." << std::endl;
 }
 
 PresidentialPardonForm &PresidentialPardonForm::operator=(const PresidentialPardonForm &obj) {
     if (this != &obj) {
         AForm::operator=(obj);
-        _target = obj._target;
+        target_ = obj.target_;
         std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
     }
     return *this;
@@ -33,6 +33,6 @@ std::ostream &operator<<(std::ostream &out, const PresidentialPardonForm &obj) {
 
 void PresidentialPardonForm::execute(Bureaucrat const &executor) const {
     validateExecutionRequirements(executor);
-    std::cout << _target << " has been pardoned by Zaphod Beeblebrox." << std::endl;
+    std::cout << target_ << " has been pardoned by Zaphod Beeblebrox." << std::endl;
 }
 

--- a/cpp05/ex03/src/PresidentialPardonForm.cpp
+++ b/cpp05/ex03/src/PresidentialPardonForm.cpp
@@ -18,17 +18,9 @@ PresidentialPardonForm &PresidentialPardonForm::operator=(const PresidentialPard
     if (this != &obj) {
         AForm::operator=(obj);
         target_ = obj.target_;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << std::endl;
     }
     return *this;
-}
-
-std::ostream &operator<<(std::ostream &out, const PresidentialPardonForm &obj) {
-    std::cout << "Type: " << BOLDWHITE << obj.getName() << RESET
-              << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
-              << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
-              << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
-    return (out);
 }
 
 void PresidentialPardonForm::execute(Bureaucrat const &executor) const {

--- a/cpp05/ex03/src/RobotomyRequestForm.cpp
+++ b/cpp05/ex03/src/RobotomyRequestForm.cpp
@@ -1,7 +1,7 @@
 #include "../include/RobotomyRequestForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-RobotomyRequestForm::RobotomyRequestForm(const std::string &target) : AForm("RobotomyRequestForm", 72, 45), _target(target) {
+RobotomyRequestForm::RobotomyRequestForm(const std::string &target) : AForm("RobotomyRequestForm", 72, 45), target_(target) {
     std::cout << BOLDGREEN << "RobotomyRequestForm constructed! " << std::endl << RESET;
 }
 
@@ -10,14 +10,14 @@ RobotomyRequestForm::~RobotomyRequestForm()
     std::cout << DIM << GRAY << "RobotomyRequestForm destructed. " << std::endl << RESET;
 }
 
-RobotomyRequestForm::RobotomyRequestForm(const RobotomyRequestForm &obj) : AForm(obj), _target(obj._target) {
+RobotomyRequestForm::RobotomyRequestForm(const RobotomyRequestForm &obj) : AForm(obj), target_(obj.target_) {
     std::cout << CYAN << "Copy!" << RESET << " New " << obj.getName() << " created." << std::endl;
 }
 
 RobotomyRequestForm &RobotomyRequestForm::operator=(const RobotomyRequestForm &obj) {
     if (this != &obj) {
         AForm::operator=(obj);
-        _target = obj._target;
+        target_ = obj.target_;
         std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
     }
     return *this;
@@ -37,11 +37,11 @@ void RobotomyRequestForm::execute(Bureaucrat const &executor) const {
     std::srand(std::time(NULL));
     if (std::rand() % 2)
     {
-        std::cout << _target << " has been robotomized successfully." << std::endl;
+        std::cout << target_ << " has been robotomized successfully." << std::endl;
     }
     else
     {
-        std::cout << "The robotomy failed on " << _target << "." << std::endl;
+        std::cout << "The robotomy failed on " << target_ << "." << std::endl;
     }
 }
 

--- a/cpp05/ex03/src/RobotomyRequestForm.cpp
+++ b/cpp05/ex03/src/RobotomyRequestForm.cpp
@@ -18,17 +18,9 @@ RobotomyRequestForm &RobotomyRequestForm::operator=(const RobotomyRequestForm &o
     if (this != &obj) {
         AForm::operator=(obj);
         target_ = obj.target_;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << std::endl;
     }
     return *this;
-}
-
-std::ostream &operator<<(std::ostream &out, const RobotomyRequestForm &obj) {
-    std::cout << "Type: " << BOLDWHITE << obj.getName() << RESET
-              << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
-              << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
-              << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
-    return (out);
 }
 
 void RobotomyRequestForm::execute(Bureaucrat const &executor) const {

--- a/cpp05/ex03/src/ShrubberyCreationForm.cpp
+++ b/cpp05/ex03/src/ShrubberyCreationForm.cpp
@@ -1,7 +1,7 @@
 #include "../include/ShrubberyCreationForm.hpp"
 #include "../include/Bureaucrat.hpp"
 
-ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target) : AForm("ShrubberyCreationForm", 145, 137), _target(target) {
+ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target) : AForm("ShrubberyCreationForm", 145, 137), target_(target) {
     std::cout << BOLDGREEN << "ShrubberyCreationForm constructed! " << std::endl << RESET;
 }
 
@@ -10,14 +10,14 @@ ShrubberyCreationForm::~ShrubberyCreationForm()
     std::cout << DIM << GRAY << "ShrubberyCreationForm destructed. " << std::endl << RESET;
 }
 
-ShrubberyCreationForm::ShrubberyCreationForm(const ShrubberyCreationForm &obj) : AForm(obj), _target(obj._target) {
+ShrubberyCreationForm::ShrubberyCreationForm(const ShrubberyCreationForm &obj) : AForm(obj), target_(obj.target_) {
     std::cout << CYAN << "Copy!" << RESET << " New " << obj.getName() << " created." << std::endl;
 }
 
 ShrubberyCreationForm &ShrubberyCreationForm::operator=(const ShrubberyCreationForm &obj) {
     if (this != &obj) {
         AForm::operator=(obj);
-        _target = obj._target;
+        target_ = obj.target_;
         std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
     }
     return *this;
@@ -33,7 +33,7 @@ std::ostream &operator<<(std::ostream &out, const ShrubberyCreationForm &obj) {
 
 void ShrubberyCreationForm::execute(Bureaucrat const &executor) const {
     validateExecutionRequirements(executor);
-    std::ofstream myFile((_target + "_shrubbery").c_str());
+    std::ofstream myFile((target_ + "_shrubbery").c_str());
     if (myFile) {
         myFile << "        /\\ \n"
                   "       /**\\ \n"

--- a/cpp05/ex03/src/ShrubberyCreationForm.cpp
+++ b/cpp05/ex03/src/ShrubberyCreationForm.cpp
@@ -18,17 +18,9 @@ ShrubberyCreationForm &ShrubberyCreationForm::operator=(const ShrubberyCreationF
     if (this != &obj) {
         AForm::operator=(obj);
         target_ = obj.target_;
-        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << " Note that there's nothing unique to this form to be copied." << std::endl;
+        std::cout << MAGENTA << "Copy assignment operator called!" << RESET << std::endl;
     }
     return *this;
-}
-
-std::ostream &operator<<(std::ostream &out, const ShrubberyCreationForm &obj) {
-    std::cout << "Type: " << BOLDWHITE << obj.getName() << RESET
-              << ", signed: " << BOLDWHITE << std::boolalpha << obj.getIsSigned() << RESET
-              << ", sign grade: " << BOLDWHITE << obj.getMinSignGrade() << RESET
-              << ", execution grade: " << BOLDWHITE << obj.getMinExecGrade() << RESET << std::endl;
-    return (out);
 }
 
 void ShrubberyCreationForm::execute(Bureaucrat const &executor) const {

--- a/cpp05/ex03/test/BureaucratTest.cpp
+++ b/cpp05/ex03/test/BureaucratTest.cpp
@@ -48,7 +48,7 @@ int main()
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 6: FUNCIONALITY: INCREMENT AND DECREMENT GRADE =====" << RESET << std::endl;
     {
         std::cout << CYAN;
-        Bureaucrat a6("A6", 100);
+        Bureaucrat a6("A6", 3);
         std::cout << BOLDGREEN;
         a6.incrementGrade();
         std::cout << BOLDYELLOW;
@@ -60,9 +60,7 @@ int main()
     {
         try
         {
-            std::cout << BRIGHT_CYAN;
             Bureaucrat a7("A7", 0);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -70,28 +68,26 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: DECREMENTING HIGHEST GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 8: HIGH EXCEPTION: INCREMENTING HIGHEST GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a8("A8", 1);
         try
         {
-            std::cout << BRIGHT_BLUE;
-            Bureaucrat a8("A8", 1);
-            a8.decrementGrade();
-            std::cout << DIM << GRAY;
+            a8.incrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << BOLDYELLOW << "\n===== TEST 9: LOW EXCEPTION: INITIALIZING WITH BELOW MINUMUM GRADE (151) =====" << RESET << std::endl;
     {
         try
         {
-            std::cout << BRIGHT_MAGENTA;
             Bureaucrat a9("A9", 151);
-            std::cout << DIM << GRAY;
         }
         catch (std::exception &e)
         {
@@ -99,19 +95,19 @@ int main()
         }
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: INCREMENTING MINIMUM GRADE =====" << RESET << std::endl;
+    std::cout << RESET << BOLDYELLOW << "\n===== TEST 10: LOW EXCEPTION: DECREMENTING MINIMUM GRADE =====" << RESET << std::endl;
     {
+        std::cout << CYAN;
+        Bureaucrat a10("A10", 150);
         try
         {
-            std::cout << BRIGHT_GREEN;
-            Bureaucrat a10("A10", 150);
-            a10.incrementGrade();
-            std::cout << DIM << GRAY;
+            a10.decrementGrade();
         }
         catch (std::exception &e)
         {
             std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
         }
+        std::cout << DIM << GRAY;
     }
 
     std::cout << RESET << std::endl;

--- a/cpp05/ex03/test/InternTest.cpp
+++ b/cpp05/ex03/test/InternTest.cpp
@@ -2,23 +2,31 @@
 #include "../include/Colors.hpp"
 #include "../include/Intern.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
-
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: INTERN CREATION FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+    printTestLine("1", "FUNCTIONALITY –  INTERN CREATION FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         Intern int1;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: INTERN CREATION FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  INTERN FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         Intern int2;
         Intern int2copy(int2);
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: ERROR: FAIL TO CREATE A FORM DUE TO TYPO =====" << RESET << std::endl;
+    printTestLine("3", "ERROR – FAIL TO CREATE A FORM DUE TO TYPO");
     {
         std::cout << std::endl;
         Intern int3;
@@ -26,7 +34,7 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCCESFULLY CREATE ALL FORMS =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY – SUCCESFULLY CREATE ALL FORMS");
     {
         std::cout << std::endl;
         Intern int3;
@@ -40,37 +48,42 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: INTERN CREATE SHRUBBERY FORM, BUREAUCRAT SIGNS AND EXECUTE =====" << RESET << std::endl;
+    printTestLine("5", "FUNCTIONALITY – INTERN CREATE ALL FORMS, BUREAUCRAT SIGNS AND EXECUTE");
     {
-        std::cout << std::endl;
+        try
+        {
+            std::cout << std::endl;
 
-        Bureaucrat bur1("Herr Bureaucrat", 1);
-        std::cout << std::endl;
+            Bureaucrat bur1("Herr Bureaucrat", 1);
+            std::cout << std::endl;
 
-        Intern int3;
-        std::cout << std::endl;
+            Intern int3;
+            std::cout << std::endl;
 
-        AForm *f1 = int3.makeForm("shrubbery creation", "target");
-        AForm *f2 = int3.makeForm("robotomy request", "target");
-        AForm *f3 = int3.makeForm("presidential pardon", "target");
-        std::cout << std::endl;
+            AForm *f1 = int3.makeForm("shrubbery creation", "target");
+            AForm *f2 = int3.makeForm("robotomy request", "target");
+            AForm *f3 = int3.makeForm("presidential pardon", "target");
+            std::cout << std::endl;
 
-        bur1.signForm(*f1);
-        bur1.executeForm(*f1);
-        delete f1;
-        std::cout << std::endl;
+            bur1.signForm(*f1);
+            bur1.executeForm(*f1);
+            delete f1;
+            std::cout << std::endl;
 
-        bur1.signForm(*f2);
-        bur1.executeForm(*f2);
-        delete f2;
-        std::cout << std::endl;
+            bur1.signForm(*f2);
+            bur1.executeForm(*f2);
+            delete f2;
+            std::cout << std::endl;
 
-        bur1.signForm(*f3);
-        bur1.executeForm(*f3);
-        delete f3;
-        std::cout << std::endl;
-
-        std::cout << std::endl;
+            bur1.signForm(*f3);
+            bur1.executeForm(*f3);
+            delete f3;
+            std::cout << std::endl;
+        }
+        catch (std::exception &e)
+        {
+            std::cout << BOLDRED << "Caught exception during test 5: " << e.what() << RESET << std::endl;
+        }
     }
 
     return 0;

--- a/cpp05/ex03/test/PresidentialTest.cpp
+++ b/cpp05/ex03/test/PresidentialTest.cpp
@@ -2,34 +2,42 @@
 #include "../include/Colors.hpp"
 #include "../include/PresidentialPardonForm.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
-
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: PRESIDENTIAL PARDON FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+    printTestLine("1", "FUNCTIONALITY –  PRESIDENTIAL PARDON CREATION FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         PresidentialPardonForm form1("oi");
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: PRESIDENTIAL PARDON FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  PRESIDENTIAL PARDON FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         PresidentialPardonForm form2("oi");
         PresidentialPardonForm form2copy(form2);
     }
 
-
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: SUCESSFULLY SIGN A FORM =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY –  SUCESSFULLY SIGN A FORM");
     {
         std::cout << GRAY << "Quick info: In order to sign Presidential Form, a Bureaucrat needs grade 25." << RESET << std::endl;
         std::cout << std::endl;
         PresidentialPardonForm form6("oi");
-        Bureaucrat b1("Bureaucrat 1", 5);
+        Bureaucrat b1("Bureaucrat 1", 25);
         b1.signForm(form6);
+        // b1.executeForm(form6); //Bureaucrat won't be able to execute
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY EXECUTE PARDON =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY –  SUCESSFULLY EXECUTE FORM");
     {
         std::cout << GRAY << "Quick info: In order to execute Presidential Form, a Bureaucrat needs grade 5." << RESET << std::endl;
         PresidentialPardonForm form6("oi");
@@ -39,13 +47,23 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: ERROR: TRYING TO EXECUTE ROBOTOMY WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("5", "ERROR –  TRYING TO EXECUTE FORM WITH NOT ENOUGH GRADE");
     {
         std::cout << GRAY << "Quick info: In order to execute Presidential Form, a Bureaucrat needs grade 5." << RESET << std::endl;
         std::cout << std::endl;
         PresidentialPardonForm form6("oi");
         Bureaucrat b1("Bureaucrat 3", 6);
         b1.signForm(form6);
+        b1.executeForm(form6);
+        std::cout << std::endl;
+    }
+
+    printTestLine("6", "ERROR –  TRYING TO EXECUTE UNSIGNED FORM");
+    {
+        std::cout << std::endl;
+        PresidentialPardonForm form6("oi");
+        Bureaucrat b1("Bureaucrat 6", 3);
+        // b1.signForm(form6);
         b1.executeForm(form6);
         std::cout << std::endl;
     }

--- a/cpp05/ex03/test/RobotomyTest.cpp
+++ b/cpp05/ex03/test/RobotomyTest.cpp
@@ -2,16 +2,24 @@
 #include "../include/Colors.hpp"
 #include "../include/RobotomyRequestForm.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
-
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: ROBOTOMY REQUEST FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+        printTestLine("1", "FUNCTIONALITY –  ROBOTOMY REQUEST FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         RobotomyRequestForm form1("oi");
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: ROBOTOMY REQUEST FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  ROBOTOMY REQUEST FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         RobotomyRequestForm form2("oi");
@@ -19,17 +27,18 @@ int main()
     }
 
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: SUCESSFULLY SIGN A FORM =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY –  SUCESSFULLY SIGN A FORM");
     {
         std::cout << GRAY << "Quick info: In order to sign Robotomy Form, a Bureaucrat needs grade 72." << RESET << std::endl;
         std::cout << std::endl;
         RobotomyRequestForm form6("oi");
-        Bureaucrat b1("Bureaucrat 6", 145);
+        Bureaucrat b1("Bureaucrat 6", 72);
+        //b1.executeForm(form6); //Bureaucrat won't be able to execute
         b1.signForm(form6);
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY EXECUTE ROBOTOMY =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY –  SUCESSFULLY EXECUTE FORM");
     {
         std::cout << GRAY << "Quick info: In order to execute Robotomy Form, a Bureaucrat needs grade 45." << RESET << std::endl;
         RobotomyRequestForm form6("oi");
@@ -39,13 +48,23 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: ERROR: TRYING TO EXECUTE ROBOTOMY WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("5", "ERROR –  TRYING TO EXECUTE FORM WITH NOT ENOUGH GRADE");
     {
         std::cout << GRAY << "Quick info: In order to execute Robotomy Form, a Bureaucrat needs grade 45." << RESET << std::endl;
         std::cout << std::endl;
         RobotomyRequestForm form6("oi");
         Bureaucrat b1("Bureaucrat 6", 71);
         b1.signForm(form6);
+        b1.executeForm(form6);
+        std::cout << std::endl;
+    }
+
+    printTestLine("6", "ERROR –  TRYING TO EXECUTE UNSIGNED FORM");
+    {
+        std::cout << std::endl;
+        RobotomyRequestForm form6("oi");
+        Bureaucrat b1("Bureaucrat 6", 144);
+        //b1.signForm(form6);
         b1.executeForm(form6);
         std::cout << std::endl;
     }

--- a/cpp05/ex03/test/ShrubberyTest.cpp
+++ b/cpp05/ex03/test/ShrubberyTest.cpp
@@ -2,34 +2,43 @@
 #include "../include/Colors.hpp"
 #include "../include/ShrubberyCreationForm.hpp"
 
+static void printTestLine(std::string num, std::string message)
+{
+    std::cout << std::endl
+              << RESET << BOLDYELLOW << "\n===== TEST "
+              << num << ": "
+              << message
+              << " ===== " << RESET << std::endl;
+}
+
 int main()
 {
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 1: SCHRUBBERY CREATION FORM CONSTRUCTION & DESTRUCTION =====" << RESET << std::endl;
+    printTestLine("1", "FUNCTIONALITY –  SHRUBBERY CREATION FORM CONSTRUCTION & DESTRUCTION");
     {
         std::cout << std::endl;
         ShrubberyCreationForm form1("oi");
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 2: SCHRUBBERY CREATION FORM COPY CONSTRUCTOR =====" << RESET << std::endl;
+    printTestLine("2", "FUNCTIONALITY –  SHRUBBERY CREATION FORM COPY CONSTRUCTOR");
     {
         std::cout << std::endl;
         ShrubberyCreationForm form2("oi");
         ShrubberyCreationForm form2copy(form2);
     }
 
-
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 3: FUNCTIONALITY: SUCESSFULLY SIGN A FORM =====" << RESET << std::endl;
+    printTestLine("3", "FUNCTIONALITY –  SUCESSFULLY SIGN A FORM");
     {
         std::cout << GRAY << "Quick info: In order to sign Shrubbery Form, a Bureaucrat needs grade 145." << RESET << std::endl;
         std::cout << std::endl;
         ShrubberyCreationForm form6("oi");
         Bureaucrat b1("Bureaucrat 6", 145);
         b1.signForm(form6);
+        //b1.executeForm(form6); //Bureaucrat won't be able to execute
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 4: FUNCTIONALITY: SUCESSFULLY EXECUTE SHRUBBERY =====" << RESET << std::endl;
+    printTestLine("4", "FUNCTIONALITY –  SUCESSFULLY EXECUTE FORM");
     {
         std::cout << GRAY << "Quick info: In order to execute Shrubbery Form, a Bureaucrat needs grade 137." << RESET << std::endl;
         ShrubberyCreationForm form6("oi");
@@ -39,7 +48,7 @@ int main()
         std::cout << std::endl;
     }
 
-    std::cout << RESET << BOLDYELLOW << "\n===== TEST 5: ERROR: TRYING TO EXECUTE SHRUBBERY WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
+    printTestLine("5", "ERROR –  TRYING TO EXECUTE FORM WITH NOT ENOUGH GRADE");
     {
         std::cout << GRAY << "Quick info: In order to execute Shrubbery Form, a Bureaucrat needs grade 137." << RESET << std::endl;
         std::cout << std::endl;
@@ -50,33 +59,15 @@ int main()
         std::cout << std::endl;
     }
 
-    // std::cout << std::endl
-    //           << RESET << BOLDYELLOW << "\n===== TEST 5: FUNCTIONALITY: FORM COPY ASSIGNMENT WITH DIFFERENT BOOLS =====" << RESET << std::endl;
-    // {
-    //     std::cout << std::endl;
-    //     ShrubberyCreationForm form7;
-    //     ShrubberyCreationForm aux;
-    //     Bureaucrat b2;
-    //     b2.signShrubberyCreationForm(form7);
-    //     aux = form7;
-    // }
-
-    // std::cout << std::endl
-    //           << RESET << BOLDYELLOW << "\n===== TEST 6: ERROR: TRYING TO SIGN A FORM WITH NOT ENOUGH GRADE =====" << RESET << std::endl;
-    // {
-    //     try
-    //     {
-    //         std::cout << std::endl;
-    //         ShrubberyCreationForm form7("ShrubberyCreationForm 7", 100, 100);
-    //         Bureaucrat b2("Bureaucrat 7", 140);
-    //         b2.signShrubberyCreationForm(form7);
-    //         std::cout << std::endl;
-    //     }
-    //     catch (std::exception &e)
-    //     {
-    //         std::cout << BOLDRED << "Caught exception: " << e.what() << RESET << std::endl;
-    //     }
-    // }
+    printTestLine("6", "ERROR –  TRYING TO EXECUTE UNSIGNED FORM");
+    {
+        std::cout << std::endl;
+        ShrubberyCreationForm form6("oi");
+        Bureaucrat b1("Bureaucrat 6", 144);
+        //b1.signForm(form6);
+        b1.executeForm(form6);
+        std::cout << std::endl;
+    }
 
     return 0;
 }


### PR DESCRIPTION
### Refactors

- Renamed private member variables in Bureaucrat and Form classes for consistency (name_, grade_, isSigned_, etc.).

- Updated all derived AForm classes to use the base class’s operator<< overload for uniform output.

- Unified test output formatting with the new printTestLine() helper function.

### Fixes

- Corrected the rules for incrementing and decrementing Bureaucrat grades to properly trigger exceptions at boundaries.

- Fixed BureaucratTest to ensure all exception cases are triggered.

- Adjusted Form signing logic to prevent redundant signing or invalid operations.